### PR TITLE
Enforce rails < 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Rails 3 servers concurrently with your Rails 2 cluster to verify everything is
 fine and performance is acceptable without
 having to do the all-in switch.
 
+_Please Note_ this gem is not intended to be loaded in Rails 4. If you're using
+Rails 4, you've already got all of this gem's functionality!
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/rails_4_session_flash_backport.rb
+++ b/lib/rails_4_session_flash_backport.rb
@@ -7,8 +7,6 @@ when 2
   require 'rails_4_session_flash_backport/rails2/session_with_indifferent_access'
 when 3
   require 'rails_4_session_flash_backport/rails3/flash_hash'
-when 4
-  Rails.logger.warn "You're on Rails 4 so it's probably safe to remove the rails_4_session_flash_backport gem!"
 else
   Rails.logger.warn "rails_4_session_flash_backport doesnt yet do anything on Rails #{Rails.version}"
 end

--- a/rails_4_session_flash_backport.gemspec
+++ b/rails_4_session_flash_backport.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+
+  gem.add_runtime_dependency 'rails', '< 4.0.0'
 end


### PR DESCRIPTION
Since this is a backport of Rails 4 functionality to Rails 2/3, it isn't intended to work on Rails 4. This PR adds an explicit dependency to the gem, which will prevent that scenario.

Fixes #10 
