### PR TITLE
Casting `Hash.select` to `Hash` (Fixes #19)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler -v '~> 1.13'
 rvm:
   - 1.9.3
   - 2.0.0

--- a/lib/rails_4_session_flash_backport/rails2/flash_hash.rb
+++ b/lib/rails_4_session_flash_backport/rails2/flash_hash.rb
@@ -31,7 +31,14 @@ module ActionController #:nodoc:
 
       def to_session_value
         return nil if empty?
-        discard = @used.select { |key, used| used }.keys
+        with_values = @used.select { |key, used| used }
+
+        if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('1.8.7') ||
+           Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
+          with_values = with_values.to_h
+        end
+
+        discard = with_values.keys
         {'flashes' => Hash[to_a].except(*discard)}
       end
 


### PR DESCRIPTION
`Hash.select` in Ruby 1.8.7 returns an `Array` (see https://ruby-doc.org/core-1.8.7/Hash.html#method-i-select), while it returns a `Hash` since Ruby 1.9.1 (see https://ruby-doc.org/core-1.9.1/Hash.html#method-i-select).