### PR TITLE
Get newest version of bundler for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler -v '~> 1.13'
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
The builds are using Bundler [1.7.6](https://travis-ci.org/envato/rails_4_session_flash_backport/jobs/178558198#L136) which is quite an old version and
many of the [bugs](https://travis-ci.org/envato/rails_4_session_flash_backport/jobs/178558215#L178) that are seeing are fixed in newer versions of
Bundler. This ensures we are always on latest pre release for all
builds.