### PR TITLE
Ensure `Hash#select`'s results are a Hash

### DIFF
--- a/lib/rails_4_session_flash_backport/rails2/flash_hash.rb
+++ b/lib/rails_4_session_flash_backport/rails2/flash_hash.rb
@@ -31,8 +31,16 @@ module ActionController #:nodoc:
 
       def to_session_value
         return nil if empty?
-        discard = @used.select { |key, used| used }.keys
+        discard = hashify(@used.select { |_, used| used }).keys
         {'flashes' => Hash[to_a].except(*discard)}
+      end
+
+      def hashify(selected)
+        if selected.respond_to?(:to_h)
+          selected.to_h
+        else
+          selected
+        end
       end
 
       def store(session, key = "flash")


### PR DESCRIPTION
#### Context

https://github.com/envato/rails_4_session_flash_backport/pull/20/files#r101234532

#### Change

Wrap the call to `@used.select` in a method that returns a Hash.

#### Cc

@zedtux & @jacobbednarz

Fixes #19