### PR TITLE
Move upper gem restrictions to < 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 before_install:
   - gem install bundler -v '~> 1.13'
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
   - 2.0.0
   - 2.1.5
   - 2.2.0
+  - 2.3.3
+  - 2.4.0
 gemfile:
   - gemfiles/Gemfile.rails-2.3.x
   - gemfiles/Gemfile.rails-3.0.x

--- a/gemfiles/Gemfile.rails-2.3.x.lock
+++ b/gemfiles/Gemfile.rails-2.3.x.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     rails_4_session_flash_backport (0.2.0)
-      rails (>= 2.0, < 4.3)
+      rails (>= 2.0, < 5)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile.rails-3.0.x.lock
+++ b/gemfiles/Gemfile.rails-3.0.x.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     rails_4_session_flash_backport (0.2.0)
-      rails (>= 2.0, < 4.3)
+      rails (>= 2.0, < 5)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile.rails-3.1.x.lock
+++ b/gemfiles/Gemfile.rails-3.1.x.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     rails_4_session_flash_backport (0.2.0)
-      rails (>= 2.0, < 4.3)
+      rails (>= 2.0, < 5)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile.rails-3.2.x.lock
+++ b/gemfiles/Gemfile.rails-3.2.x.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     rails_4_session_flash_backport (0.2.0)
-      rails (>= 2.0, < 4.3)
+      rails (>= 2.0, < 5)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile.rails-4.0.x.lock
+++ b/gemfiles/Gemfile.rails-4.0.x.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     rails_4_session_flash_backport (0.2.0)
-      rails (>= 2.0, < 4.3)
+      rails (>= 2.0, < 5)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile.rails-4.1.x.lock
+++ b/gemfiles/Gemfile.rails-4.1.x.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     rails_4_session_flash_backport (0.2.0)
-      rails (>= 2.0, < 4.3)
+      rails (>= 2.0, < 5)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/Gemfile.rails-4.2.x.lock
+++ b/gemfiles/Gemfile.rails-4.2.x.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     rails_4_session_flash_backport (0.2.0)
-      rails (>= 2.0, < 4.3)
+      rails (>= 2.0, < 5)
 
 GEM
   remote: https://rubygems.org/

--- a/rails_4_session_flash_backport.gemspec
+++ b/rails_4_session_flash_backport.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'rails', '>= 2.0', '< 4.3'
+  gem.add_runtime_dependency 'rails', '>= 2.0', '< 5'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
- Update the gemspec to allow any version of Rails 4 as long as it is < 5.
- Add test coverage for MRI 2.3 and 2.4