### PR TITLE
Rails 4 #to_session_value should include discard as array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
 language: ruby
 before_install:
   - gem install bundler -v 1.16.0
-  - gem pristine bundler
 rvm:
   - 1.9.3
-  #- 2.0.0
-  #- 2.1.5
-  #- 2.2.0
+  - 2.0.0
+  - 2.1.5
+  - 2.2.0
 gemfile:
   - gemfiles/Gemfile.rails-2.3.x
-  #- gemfiles/Gemfile.rails-3.0.x
-  #- gemfiles/Gemfile.rails-3.1.x
-  #- gemfiles/Gemfile.rails-3.2.x
-  #- gemfiles/Gemfile.rails-4.0.x
-  #- gemfiles/Gemfile.rails-4.1.x
-  #- gemfiles/Gemfile.rails-4.2.x
+  - gemfiles/Gemfile.rails-3.0.x
+  - gemfiles/Gemfile.rails-3.1.x
+  - gemfiles/Gemfile.rails-3.2.x
+  - gemfiles/Gemfile.rails-4.0.x
+  - gemfiles/Gemfile.rails-4.1.x
+  - gemfiles/Gemfile.rails-4.2.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ before_install:
   - gem install bundler -v 1.16.0
 rvm:
   - 1.9.3
-  - 2.0.0
-  - 2.1.5
-  - 2.2.0
+  #- 2.0.0
+  #- 2.1.5
+  #- 2.2.0
 gemfile:
   - gemfiles/Gemfile.rails-2.3.x
-  - gemfiles/Gemfile.rails-3.0.x
-  - gemfiles/Gemfile.rails-3.1.x
-  - gemfiles/Gemfile.rails-3.2.x
-  - gemfiles/Gemfile.rails-4.0.x
-  - gemfiles/Gemfile.rails-4.1.x
-  - gemfiles/Gemfile.rails-4.2.x
+  #- gemfiles/Gemfile.rails-3.0.x
+  #- gemfiles/Gemfile.rails-3.1.x
+  #- gemfiles/Gemfile.rails-3.2.x
+  #- gemfiles/Gemfile.rails-4.0.x
+  #- gemfiles/Gemfile.rails-4.1.x
+  #- gemfiles/Gemfile.rails-4.2.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 before_install:
   - gem install bundler -v 1.16.0
+  - gem pristine bundler
 rvm:
   - 1.9.3
   #- 2.0.0

--- a/gemfiles/Gemfile.rails-2.3.x.lock
+++ b/gemfiles/Gemfile.rails-2.3.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rails_4_session_flash_backport (0.2.1)
+    rails_4_session_flash_backport (0.2.2)
       rails (>= 2.0, < 4.3)
 
 GEM

--- a/gemfiles/Gemfile.rails-3.0.x.lock
+++ b/gemfiles/Gemfile.rails-3.0.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rails_4_session_flash_backport (0.2.1)
+    rails_4_session_flash_backport (0.2.2)
       rails (>= 2.0, < 4.3)
 
 GEM

--- a/gemfiles/Gemfile.rails-3.1.x.lock
+++ b/gemfiles/Gemfile.rails-3.1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rails_4_session_flash_backport (0.2.1)
+    rails_4_session_flash_backport (0.2.2)
       rails (>= 2.0, < 4.3)
 
 GEM

--- a/gemfiles/Gemfile.rails-3.2.x.lock
+++ b/gemfiles/Gemfile.rails-3.2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rails_4_session_flash_backport (0.2.1)
+    rails_4_session_flash_backport (0.2.2)
       rails (>= 2.0, < 4.3)
 
 GEM

--- a/gemfiles/Gemfile.rails-4.0.x.lock
+++ b/gemfiles/Gemfile.rails-4.0.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rails_4_session_flash_backport (0.2.1)
+    rails_4_session_flash_backport (0.2.2)
       rails (>= 2.0, < 4.3)
 
 GEM

--- a/gemfiles/Gemfile.rails-4.1.x.lock
+++ b/gemfiles/Gemfile.rails-4.1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rails_4_session_flash_backport (0.2.1)
+    rails_4_session_flash_backport (0.2.2)
       rails (>= 2.0, < 4.3)
 
 GEM

--- a/gemfiles/Gemfile.rails-4.2.x.lock
+++ b/gemfiles/Gemfile.rails-4.2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rails_4_session_flash_backport (0.2.1)
+    rails_4_session_flash_backport (0.2.2)
       rails (>= 2.0, < 4.3)
 
 GEM

--- a/lib/rails_4_session_flash_backport/rails4/flash_hash.rb
+++ b/lib/rails_4_session_flash_backport/rails4/flash_hash.rb
@@ -32,7 +32,7 @@ module ActionDispatch
       def to_session_value
         flashes_to_keep = @flashes.except(*@discard)
         return nil if flashes_to_keep.empty?
-        {'flashes' => flashes_to_keep}
+        {'discard' => @discard.to_a, 'flashes' => flashes_to_keep}
       end
     end
   end

--- a/lib/rails_4_session_flash_backport/version.rb
+++ b/lib/rails_4_session_flash_backport/version.rb
@@ -1,3 +1,3 @@
 module Rails4SessionFlashBackport
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/rails4/flash_hash_spec.rb
+++ b/spec/rails4/flash_hash_spec.rb
@@ -66,7 +66,7 @@ describe ActionDispatch::Flash::FlashHash, "backport" do
     end
 
     it "dumps to basic objects like rails 4" do
-      expect(flash.to_session_value).to eq("flashes" => {"greeting" => "Hello"})
+      expect(flash.to_session_value).to eq("discard" => ["farewell"], "flashes" => {"greeting" => "Hello"})
     end
   end
 end


### PR DESCRIPTION
#### Context

Upon removing this gem from our (rather large) Rails 4.1 application, errors started occurring due to FlashHash objects being initialised with discard value as nil, which [ActionDispatch ::FlashHash#stringify_array](https://github.com/rails/rails/blob/4-1-stable/actionpack/lib/action_dispatch/middleware/flash.rb#L98) doesn't like when it was trying to map over a value that doesn't exist causing the good old `undefined method 'map' for nil:NilClass` error.

When patching `#to_session_value`,  `value['discard']` should also be present, as per https://github.com/rails/rails/blob/4-0-stable/actionpack/lib/action_dispatch/middleware/flash.rb#L91

#### Changes

- Updated return value of `#to_session_value` to include `discard` as array.